### PR TITLE
Fix progress bar bug and only unzip specified files in get_data

### DIFF
--- a/get_data.py
+++ b/get_data.py
@@ -17,17 +17,22 @@ def get_data(userpath, historical, recent, hourly, verbose):
 
     #unzip the files
     print("unzipping data")
-    localdir = os.path.join(userpath,'pub','CDC','observations_germany','climate','daily','kl')
-    unzip_folder(os.path.join(localdir, 'historical'))
-    unzip_folder(os.path.join(localdir, 'recent'))
-    hour_folders = ["air_temperature", "cloud_type", "precipitation", "pressure", "soil_temperature", "solar", "sun", "visibility", "wind"]
-    for folder in hour_folders:
-        localdir = os.path.join(userpath, 'pub','CDC','observations_germany','climate','hourly', folder)
-        if folder!="solar":
+    if historical or recent:
+        localdir = os.path.join(userpath,'pub','CDC','observations_germany','climate','daily','kl')
+        if historical:
             unzip_folder(os.path.join(localdir, 'historical'))
+        if recent:
             unzip_folder(os.path.join(localdir, 'recent'))
-        else:
-            unzip_folder(localdir)
+
+    if hourly:
+        hour_folders = ["air_temperature", "cloud_type", "precipitation", "pressure", "soil_temperature", "solar", "sun", "visibility", "wind"]
+        for folder in hour_folders:
+            localdir = os.path.join(userpath, 'pub','CDC','observations_germany','climate','hourly', folder)
+            if folder!="solar":
+                unzip_folder(os.path.join(localdir, 'historical'))
+                unzip_folder(os.path.join(localdir, 'recent'))
+            else:
+                unzip_folder(localdir)
 
 
 def main():

--- a/useftp.py
+++ b/useftp.py
@@ -34,7 +34,7 @@ def download_folder(ftp, userpath,foldername, verbose):
         pperc = int(progress_bar_width*i/len(filenames)) #percentage of progressbar thats done
         sys.stdout.write("[{}{}] {}%\r".format('='*pperc,' '*(progress_bar_width-pperc), str(perc).zfill(2)))
         sys.stdout.flush()
-    sys.stdout.write("[{}] {}%\n".format('='*progress_bar_width-1, 100)) #write bar with 100%
+    sys.stdout.write("[{}] {}%\n".format('='*(progress_bar_width-1), 100)) #write bar with 100%
     sys.stdout.flush()
 
 def delete_folder(folder, verbose = True):


### PR DESCRIPTION
- There was a missing parenthesis in the line that prints the statusbar when the downloads get to 100%.

- When I told get_data to get the daily data, it tried to unzip the hourly data as well, which threw an error because it wasn't there.